### PR TITLE
Bower / Wiredep SCSS automatic import

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,10 @@
     "type": "git",
     "url": "git://github.com/components/font-awesome.git"
   },
-  "main": "css/font-awesome.css",
+  "main": [ 
+      "css/font-awesome.css",
+      "scss/font-awesome.scss"
+  ],
   "license": [
     "MIT",
     "OFL-1.1"


### PR DESCRIPTION
[Wiredep](https://github.com/taptapship/wiredep) / [Grunt-Wiredep](https://github.com/stephenplusplus/grunt-wiredep) uses the [main attribute in bower.json](http://bower.io/docs/creating-packages/) to determine what assets to reference in its injected blocks. As the font-awesome.scss file is not defined, it is not discovered and subsequently is not injected into wiredep sections.

The fix is simply to add the reference to the main font-awesome.scss file to the main attribute value array, implemented in this pull request.
