### PR TITLE
Revert "Fix Bower metadata"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,14 @@
     "url": "git://github.com/components/font-awesome.git"
   },
   "main": [
-      "css/font-awesome.css"
+      "css/font-awesome.css",
+      "css/font-awesome.css.map",
+      "scss/font-awesome.scss",
+      "fonts/fontawesome-webfont.eot",
+      "fonts/fontawesome-webfont.woff",
+      "fonts/fontawesome-webfont.woff2",
+      "fonts/fontawesome-webfont.ttf",
+      "fonts/fontawesome-webfont.svg"
   ],
   "license": [
     "MIT",


### PR DESCRIPTION
This reverts commit 02633e574950792f0a75d6f2fdf05006f3e4f2e3.

Fixes #41

The bower.json spec for `main` is over at:
https://github.com/bower/spec/blob/master/json.md#main

It references the scss and js, not the binary assets. @colincameron Thoughts?